### PR TITLE
Update docblocks with official documentation

### DIFF
--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -6,15 +6,20 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * An HTTP middleware component participates in processing an HTTP message,
- * either by acting on the request or the response. This interface defines the
- * methods required to use the middleware.
+ * Participant in processing a server request and response.
+ *
+ * An HTTP middleware component participates in processing an HTTP message:
+ * by acting on the request, generating the response, or forwarding the
+ * request to a subsequent middleware and possibly acting on its response.
  */
 interface MiddlewareInterface
 {
     /**
-     * Process an incoming server request and return a response, optionally delegating
-     * response creation to a handler.
+     * Process an incoming server request.
+     *
+     * Processes an incoming server request in order to produce a response.
+     * If unable to produce the response itself, it may delegate to the provided
+     * request handler to do so.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface;
 }


### PR DESCRIPTION
Interface documentation was not updated after PSR-15 was approved, which makes these interfaces out of sync with the accepted specification.

Refs php-fig/http-server-handler#4
Refs php-fig/fig-standards#1107