### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HTTP Server Request Handlers (middleware)
+HTTP Server Middleware
 ==============
 
 This repository holds the `MiddlewareInterface` related to [PSR-15 (HTTP Server Request Handlers)][psr-url].

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-HTTP Server Middleware
-======================
+HTTP Server Request Handlers (middleware)
+==============
 
-Provides the `MiddlewareInterface` of [PSR-15][psr-15].
+This repository holds the `MiddlewareInterface` related to [PSR-15 (HTTP Server Request Handlers)][psr-url].
 
-[psr-15]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md
+Note that this is not a Middleware implementation of its own. It is merely the interface that describe a Middleware.
+
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+
+[psr-url]: https://www.php-fig.org/psr/psr-15/
+[package-url]: https://packagist.org/packages/psr/http-server-middleware
+[implementation-url]: https://packagist.org/providers/psr/http-server-middleware-implementation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds the `MiddlewareInterface` related to [PSR-15 (HTTP Server 
 
 Note that this is not a Middleware implementation of its own. It is merely the interface that describe a Middleware.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-15/
 [package-url]: https://packagist.org/packages/psr/http-server-middleware


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.